### PR TITLE
Fixed JpaBatchMetadata when executing 'jpa audit add'

### DIFF
--- a/addon-jpa/addon/src/main/java/org/gvnix/addon/jpa/addon/batch/JpaBatchMetadata.java
+++ b/addon-jpa/addon/src/main/java/org/gvnix/addon/jpa/addon/batch/JpaBatchMetadata.java
@@ -128,7 +128,6 @@ public class JpaBatchMetadata extends
     }
 
     private final JpaBatchAnnotationValues annotationValues;
-    private final JpaActiveRecordMetadata activeRecordMetadata;
     private final JavaType entity;
     private final FieldMetadata entityIdentifier;
     private final JavaType listOfIdentifiersType;
@@ -155,9 +154,7 @@ public class JpaBatchMetadata extends
     public JpaBatchMetadata(String identifier, JavaType aspectName,
             PhysicalTypeMetadata governorPhysicalTypeMetadata,
             JpaBatchAnnotationValues annotationValues,
-            List<FieldMetadata> identifiers,
-            JpaActiveRecordMetadata entityActiveRecordMetadata,
-            JpaCrudAnnotationValues crudAnnotationValues,
+            List<FieldMetadata> identifiers, String entityPlural,
             JpaAuditMetadata auditMetada, boolean hasEntityListeners) {
         super(identifier, aspectName, governorPhysicalTypeMetadata);
         Validate.isTrue(isValid(identifier), "Metadata identification string '"
@@ -175,9 +172,6 @@ public class JpaBatchMetadata extends
         // Roo only use one field for pk
         this.entityIdentifier = identifiers.iterator().next();
 
-        // Store jpa ActiveRecord info
-        this.activeRecordMetadata = entityActiveRecordMetadata;
-
         // Store auditMetadata
         this.auditMetadata = auditMetada;
 
@@ -190,10 +184,10 @@ public class JpaBatchMetadata extends
                 && !this.hasEntityListeners;
 
         // Get entity name
-        this.entityName = StringUtils.isBlank(this.activeRecordMetadata
-                .getEntityName()) ? entity.getSimpleTypeName()
-                : this.activeRecordMetadata.getEntityName();
-        this.entityPlural = entityActiveRecordMetadata.getPlural();
+        this.entityName = entity.getSimpleTypeName();
+
+        // Get entity plural name
+        this.entityPlural = entityPlural;
 
         this.listOfIdentifiersType = new JavaType(
                 LIST.getFullyQualifiedTypeName(), 0, DataType.TYPE, null,

--- a/addon-jpa/addon/src/main/java/org/gvnix/addon/jpa/addon/batch/JpaBatchMetadataProvider.java
+++ b/addon-jpa/addon/src/main/java/org/gvnix/addon/jpa/addon/batch/JpaBatchMetadataProvider.java
@@ -34,6 +34,7 @@ import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.ComponentContext;
 import org.springframework.roo.addon.jpa.addon.activerecord.JpaActiveRecordMetadata;
 import org.springframework.roo.addon.jpa.addon.activerecord.JpaCrudAnnotationValues;
+import org.springframework.roo.addon.plural.addon.PluralMetadata;
 import org.springframework.roo.classpath.PhysicalTypeIdentifier;
 import org.springframework.roo.classpath.PhysicalTypeMetadata;
 import org.springframework.roo.classpath.details.ClassOrInterfaceTypeDetails;
@@ -145,19 +146,9 @@ public final class JpaBatchMetadataProvider extends
         List<FieldMetadata> identifiers = getPersistenceMemberLocator()
                 .getIdentifierFields(targetEntity);
 
-        JpaActiveRecordMetadata entityMetadata = (JpaActiveRecordMetadata) getMetadataService()
-                .get(entityMetadataKey);
-
-        if (entityMetadata == null) {
-            return null;
-        }
-
         // register downstream dependency (entityActiveRecord --> jpaBatch)
         getMetadataDependencyRegistry().registerDependency(entityMetadataKey,
                 metadataIdentificationString);
-
-        JpaCrudAnnotationValues crudAnnotationValues = new JpaCrudAnnotationValues(
-                entityMetadata);
 
         // check if entity use audit
         String auditMetatadaKey = JpaAuditMetadata.createIdentifier(
@@ -172,11 +163,20 @@ public final class JpaBatchMetadataProvider extends
         boolean hasEntityListeners = getEntityListenerOperations()
                 .hasAnyListener(targetEntity);
 
+        // Getting plural
+        final String pluralId = PluralMetadata.createIdentifier(targetEntity,
+                path);
+        final PluralMetadata pluralMetadata = (PluralMetadata) getMetadataService()
+                .get(pluralId);
+        if (pluralMetadata == null) {
+            // Can't acquire the plural
+            return null;
+        }
+
         // TODO get more data
         return new JpaBatchMetadata(metadataIdentificationString, aspectName,
                 governorPhysicalTypeMetadata, annotationValues, identifiers,
-                entityMetadata, crudAnnotationValues, auditMetada,
-                hasEntityListeners);
+                pluralMetadata.getPlural(), auditMetada, hasEntityListeners);
     }
 
     /**


### PR DESCRIPTION
When doing "jpa audit add" to an entity with finders and datatables with "inline" it stopped execution because sometimes JpaBatchMetadata was null when getting JpaActiveRecordMetadata. Now JpaBatchMetadata doesn't need JpaActiveRecordMetadata for building entity plural. Now it uses Plural metadata for this task.